### PR TITLE
Removes time info from message in the logger

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -35,13 +35,12 @@ const (
 
 	EventTestFailure = "test_failure"
 
+	LogEvent      = "log"
+	LogEventLevel = "log.level"
 
-	LogEvent			= "log"
-	LogEventLevel		= "log.level"
-
-	LogLevel_INFO		= "INFO"
-	LogLevel_WARNING 	= "WARNING"
-	LogLevel_ERROR		= "ERROR"
-	LogLevel_DEBUG		= "DEBUG"
-	LogLevel_VERBOSE	= "VERBOSE"
+	LogLevel_INFO    = "INFO"
+	LogLevel_WARNING = "WARNING"
+	LogLevel_ERROR   = "ERROR"
+	LogLevel_DEBUG   = "DEBUG"
+	LogLevel_VERBOSE = "VERBOSE"
 )

--- a/testing.go
+++ b/testing.go
@@ -161,22 +161,24 @@ func loggerStdIOHandler(test *Test, stdio *StdIO) {
 		}
 		nLine := line
 		flags := log2.Flags()
+		sliceCount := 0
 		if flags&(log2.Ldate|log2.Ltime|log2.Lmicroseconds) != 0 {
 			if flags&log2.Ldate != 0 {
-				nLine = nLine[11:]
+				sliceCount = sliceCount + 11
 			}
 			if flags&(log2.Ltime|log2.Lmicroseconds) != 0 {
-				nLine = nLine[8:]
+				sliceCount = sliceCount + 9
 				if flags&log2.Lmicroseconds != 0 {
-					nLine = nLine[7:]
+					sliceCount = sliceCount + 7
 				}
-				nLine = nLine[1:]
 			}
+			nLine = nLine[sliceCount:]
 		}
 		test.span.LogFields(
 			log.String(EventType, LogEvent),
 			log.String(EventMessage, nLine),
 			log.String(LogEventLevel, LogLevel_VERBOSE),
+			log.String("log.logger", "std.Logger"),
 		)
 
 		if stdio.oldIO != nil {


### PR DESCRIPTION
this PR removes the time information appearing in the log message when using the `logger` struct. 
like: 
```go 
log.Println("Hello world")
```

In previous results we had: 
![image](https://user-images.githubusercontent.com/69803/64244655-b92e8600-cf09-11e9-9ee6-85eaac0d0d16.png)

With the PR:
![image](https://user-images.githubusercontent.com/69803/64244698-c9defc00-cf09-11e9-9161-e908fbf82866.png)

